### PR TITLE
set up dev tooling&CI for juno_k3s

### DIFF
--- a/.ansibledoctor.yml
+++ b/.ansibledoctor.yml
@@ -1,0 +1,13 @@
+exclude_files:
+  - venv/
+  - molecule/
+
+template:
+  name: readme
+  src: local>docs/
+renderer:
+  force_overwrite: True
+
+role:
+  name: juno_k3s
+

--- a/.github/workflows/molecule-test.yml
+++ b/.github/workflows/molecule-test.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+
+jobs:
+  molecule-test:
+    runs-on: self-hosted
+    strategy:
+      max-parallel: 1 # this can be faster, working on it :)
+      matrix:
+        os-target: [ubuntu22, debian12, rocky95]
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+      - name: Run molecule tests
+        env:
+          AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+        run: |
+          make test-${{ matrix.os-target }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+.devbox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Developer docs
+
+
+This will help you get started working with this role as a developer.
+
+## Prerequisites
+
+- [devbox](https://www.jetpack.io/devbox/docs/) (optional)
+  - we use it to ensure consistent version for dependencies such as python. 
+  Your local interpreter will be fine in most cases
+- GNU make
+- an authenticated AWS CLI. Run `aws sts get-caller-identity` to verify.
+
+
+## Documentation standards
+The README.md shouldn't be edited directly. Instead, edit the template in `docs/readme/README.md.j2` template and run
+`make readme` to generate the README.md.
+
+You should not:
+- document example playbooks manually. You should instead include them in the test scenario and source them from there.
+
+### Documenting variables
+Each variable should have an explicit default value in defaults/main.yml.
+
+Above the var, document it with a comment. The comment should be in the form:
+
+```
+#@var <variable name>:description: This is my description
+<variable name>: <default value>
+```
+
+
+## Developer workflow
+
+To see supported Platforms check the README or the Makefile directly.
+
+When working with this role, you can use the below `make` targets to validate it:
+
+- `make converge-<platform name>` - this spins up all needed EC2 instances on AWS and applies the example playbook to them directly.
+The example playbook it applies is defined in `molecule/ec2/converge.yml`. When testing new functionality, you can add it there.
+
+You can define multiple runs in there, to test different configurations.
+Changes to variables the user would supply themselves go there.
+Changes to tasks that the role is responsible for go into `tasks/`
+
+- `make login` - log in to one of instances you just created. We default to the controplane node.
+You can log in to any of those instances - run `venv/bin/molecule login --help` to see options
+
+- `make destroy-<platform name>` - when done working with it, clean up the dev env. Otherwise you will generate AWS costs!
+
+- `make test-<platform name>` - run the full test suite.
+Note that if one of your steps defined in `tasks/` failed, the instances will be cleaned up and you will have no ability to inspect them.
+
+That's why `make test-*` is preferrable for CI, while `converge` is better for local dev.
+You still might want to run it locally when checking for idempotency - `make test` runs the playbook twice and expects no changes flagged on the 2nd run.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+.PHONY: docs
+
+debian12_AMI = ami-02da2f5b47450f5a8
+ubuntu22_AMI = ami-04f167a56786e4b09
+rocky95_AMI = ami-05150ea4d8a533099
+
+export AWS_VPC_SUBNET_ID ?= subnet-090d8a0ac7e70b207
+export AWS_REGION ?= us-east-2
+export AWS_INSTANCE_TYPE ?= t2.large
+
+venv/bin/activate:
+	python3 -m venv venv
+	. venv/bin/activate; pip install -r requirements.txt
+	. venv/bin/activate; ansible-galaxy install -r test_requirements.yml
+
+docs: venv/bin/activate
+	venv/bin/ansible-doctor
+
+login: venv/bin/activate
+	. venv/bin/activate; venv/bin/molecule login
+
+converge-%: venv/bin/activate
+	. venv/bin/activate; AWS_AMI_ID=${$*_AMI} venv/bin/molecule -vvv converge -s ec2
+
+test-%: venv/bin/activate
+	. venv/bin/activate; AWS_AMI_ID=${$*_AMI} venv/bin/molecule -vvv test -s ec2
+
+destroy-%: venv/bin/activate
+	. venv/bin/activate; AWS_AMI_ID=${$*_AMI} venv/bin/molecule -vvv destroy -s ec2
+
+
+#tab autocomplete
+converge-debian12: converge-debian12
+converge-ubuntu22: converge-ubuntu22
+converge-rocky95: converge-rocky95
+test-debian12: test-debian12
+test-ubuntu22: test-ubuntu22
+test-rocky95: test-rocky95
+destroy-debian12: destroy-debian12
+destroy-ubuntu22: destroy-ubuntu22
+destroy-rocky95: destroy-rocky95

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # juno_k3s
+
+your role description
+
+## Table of content
+
+- [Role variables](#role-variables)
+- [Dependencies](#dependencies)
+- [License](#license)
+- [Author](#author)
+
+---
+
+## Role variables
+| Name | Default value | Description |
+|:-----|:--------------|:------------|
+| my_var |  | ['This is my description'] |
+
+
+
+## Dependencies
+
+None.
+
+## License
+
+Apache-2.0
+
+## Author
+
+Juno Innovations
+
+# Development workflow
+
+This repository comes in with a Makefile providing targets for testing & linting the role.
+:wq
+For usage examples see: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+#@var my_var:description: This is my description
+my_var: value

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,14 @@
+{
+  "$schema":  "https://raw.githubusercontent.com/jetify-com/devbox/0.14.2/.schema/devbox.schema.json",
+  "packages": ["python@3.13.3"],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,66 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-05-22T03:53:02Z",
+      "resolved": "github:NixOS/nixpkgs/a16efe5d2fc7455d7328a01f4692bfec152965b3?lastModified=1747885982&narHash=sha256-rSuxACdwx5Ndr2thpjqcG89fj8mSSp96CFoCt0yrdkY%3D"
+    },
+    "python@3.13.3": {
+      "last_modified": "2025-05-16T20:19:48Z",
+      "plugin_version": "0.0.4",
+      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#python313",
+      "source": "devbox-search",
+      "version": "3.13.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1a8xg8l3m67hxinxzzcsak9736qm9vsf-python3-3.13.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1a8xg8l3m67hxinxzzcsak9736qm9vsf-python3-3.13.3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yy0xvc2rydhrs0h1v8d7r3sql347xzz5-python3-3.13.3",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/42bxfqfrh8cwspl7szr0cw8739xv8qlq-python3-3.13.3-debug"
+            }
+          ],
+          "store_path": "/nix/store/yy0xvc2rydhrs0h1v8d7r3sql347xzz5-python3-3.13.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gbrigjhghz9v2p0zf9b2fnvs0g0yx7q4-python3-3.13.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gbrigjhghz9v2p0zf9b2fnvs0g0yx7q4-python3-3.13.3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2mab9iiwhcqwk75qwvp3zv0bvbiaq6cs-python3-3.13.3",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/9z6k8ijl2md0y2n95yprbjj4vxbfsi15-python3-3.13.3-debug"
+            }
+          ],
+          "store_path": "/nix/store/2mab9iiwhcqwk75qwvp3zv0bvbiaq6cs-python3-3.13.3"
+        }
+      }
+    }
+  }
+}

--- a/docs/readme/README.md.j2
+++ b/docs/readme/README.md.j2
@@ -1,0 +1,30 @@
+{% if not append | deep_get(role, "internal.append") %}
+{% set meta = role.meta | default({}) %}
+# {{ meta.name.value | safe_join(" ") }}
+{% endif %}
+{% if description | deep_get(meta, "description.value") %}
+{% set description = [meta.description.value] if meta.description.value is string else meta.description.value %}
+
+{{ description | map("replace", "\n\n", "\n") | safe_join("\n") }}
+{% endif %}
+
+{#      TOC      #}
+{% include '_toc.j2' %}
+
+{#      Vars      #}
+{% include '_vars.j2' %}
+
+{#      Todo      #}
+{% include '_tag.j2' %}
+
+{#      Todo      #}
+{% include '_todo.j2' %}
+
+{#      Meta      #}
+{% include '_meta.j2' %}
+
+# Development workflow
+
+This repository comes in with a Makefile providing targets for testing & linting the role.
+
+For usage examples see: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/docs/readme/_meta.j2
+++ b/docs/readme/_meta.j2
@@ -1,0 +1,31 @@
+{% set meta = role.meta | default({}) %}
+{% if meta %}
+## Dependencies
+
+{% if meta | deep_get(meta, "dependencies.value") %}
+{% if meta.dependencies.value is mapping %}
+{% set deps = meta.dependencies.value.dependencies %}
+{% else %}
+{% set deps = meta.dependencies.value %}
+{% endif %}
+{% for item in deps %}
+{% if item is string or item.role %}
+- {{ item if item is string else item.role }}
+{% endif %}
+{% endfor %}
+{% else %}
+None.
+{% endif %}
+{% if license | deep_get(meta, "license.value") %}
+
+## License
+
+{{ meta.license.value }}
+{% endif %}
+{% if author | deep_get(meta, "author.value") %}
+
+## Author
+
+{{ meta.author.value | safe_join(" ") }}
+{% endif %}
+{% endif %}

--- a/docs/readme/_tag.j2
+++ b/docs/readme/_tag.j2
@@ -1,0 +1,12 @@
+{% set tag = role.tag | default({}) %}
+{% if tag %}
+## Discovered Tags
+{% for key, item in tag | dictsort %}
+{% set is_desc = item.description is defined and item.description | safe_join(" ") | striptags %}
+
+**_{{ key }}_**{{ "\\" if is_desc else "" }}
+{% if is_desc %}
+&emsp;{{ item.description | safe_join(" ") | striptags }}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/docs/readme/_toc.j2
+++ b/docs/readme/_toc.j2
@@ -1,0 +1,17 @@
+## Table of content
+
+{% set var = role.var | default({}) %}
+{% if var %}
+- [Role variables](#role-variables)
+{% endif %}
+{% if tag %}
+- [Discovered Tags](#discovered-tags)
+{% endif %}
+{% if todo %}
+- [Open Tasks](#open-tasks)
+{% endif %}
+- [Dependencies](#dependencies)
+- [License](#license)
+- [Author](#author)
+
+---

--- a/docs/readme/_todo.j2
+++ b/docs/readme/_todo.j2
@@ -1,0 +1,19 @@
+{% set todo = role.todo | default({}) %}
+{% if todo %}
+## Open Tasks
+
+{% for key, item in todo | dictsort %}
+{% for line in item %}
+{% if line.value is defined and line.value | safe_join(" ") | striptags and key == "default" %}
+- {{ line.value | safe_join(" ") | striptags }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% for key, item in todo | dictsort %}
+{% for line in item %}
+{% if line.value is defined and line.value | safe_join(" ") | striptags and key != "default" %}
+- ({{ key }}): {{ line.value | safe_join(" ") | striptags }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}

--- a/docs/readme/_vars.j2
+++ b/docs/readme/_vars.j2
@@ -1,0 +1,9 @@
+{% set var = role.var | default({}) %}
+{% if var %}
+
+## Role variables
+| Name | Default value | Description |
+|:-----|:--------------|:------------|
+{% for key, item in var | dictsort %}| {{ key }} | {{ item.default | default('') }} | {{ item.description | default('') }} |
+{% endfor %}
+{% endif %}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for juno_k3s

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,21 @@
+galaxy_info:
+  role_name: juno_k3s
+  author: Juno Innovations
+  namespace: juno-fx
+  description: your role description
+  company: Juno Innovations
+
+  license: Apache-2.0
+
+  min_ansible_version: 2.1
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/molecule/ec2/INSTALL.rst
+++ b/molecule/ec2/INSTALL.rst
@@ -1,0 +1,22 @@
+*********************************************
+Amazon Web Services driver installation guide
+*********************************************
+
+Requirements
+============
+
+* An AWS credentials rc file
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule-ec2'

--- a/molecule/ec2/converge.yml
+++ b/molecule/ec2/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include juno_k3s"
+      ansible.builtin.include_role:
+        name: "juno-fx.juno_k3s"

--- a/molecule/ec2/create.yml
+++ b/molecule/ec2/create.yml
@@ -1,0 +1,324 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    # Run config handling
+    default_run_id: "{{ lookup('password', '/dev/null chars=ascii_lowercase length=5') }}"
+    default_run_config:
+      run_id: "{{ default_run_id }}"
+
+    run_config_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/run-config.yml"
+    run_config_from_file: "{{ (lookup('file', run_config_path, errors='ignore') or '{}') | from_yaml }}"
+    run_config: '{{ default_run_config | combine(run_config_from_file) }}'
+
+    # Platform settings handling
+    default_assign_public_ip: true
+    default_aws_profile: "{{ lookup('env', 'AWS_PROFILE') }}"
+    default_boot_wait_seconds: 120
+    default_instance_type: t3a.medium
+    default_key_inject_method: cloud-init # valid values: [cloud-init, ec2]
+    default_key_name: "molecule-{{ run_config.run_id }}"
+    default_private_key_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/id_rsa"
+    default_public_key_path: "{{ default_private_key_path }}.pub"
+    default_ssh_user: ansible
+    default_ssh_port: 22
+    default_user_data: ''
+
+    default_security_group_name: "molecule-{{ run_config.run_id }}"
+    default_security_group_description: Ephemeral security group for Molecule instances
+    default_security_group_rules:
+      - proto: tcp
+        from_port: "{{ default_ssh_port }}"
+        to_port: "{{ default_ssh_port }}"
+        cidr_ip: "0.0.0.0/0"
+      - proto: icmp
+        from_port: 8
+        to_port: -1
+        cidr_ip: "0.0.0.0/0"
+    default_security_group_rules_egress:
+      - proto: -1
+        from_port: 0
+        to_port: 0
+        cidr_ip: "0.0.0.0/0"
+
+    platform_defaults:
+      assign_public_ip: "{{ default_assign_public_ip }}"
+      aws_profile: "{{ default_aws_profile }}"
+      boot_wait_seconds: "{{ default_boot_wait_seconds }}"
+      instance_type: "{{ default_instance_type }}"
+      key_inject_method: "{{ default_key_inject_method }}"
+      key_name: "{{ default_key_name }}"
+      private_key_path: "{{ default_private_key_path }}"
+      public_key_path: "{{ default_public_key_path }}"
+      security_group_name: "{{ default_security_group_name }}"
+      security_group_description: "{{ default_security_group_description }}"
+      security_group_rules: "{{ default_security_group_rules }}"
+      security_group_rules_egress: "{{ default_security_group_rules_egress }}"
+      ssh_user: "{{ default_ssh_user }}"
+      ssh_port: "{{ default_ssh_port }}"
+      cloud_config: {}
+      image: ""
+      image_name: ""
+      image_owner: [self]
+      name: ""
+      region: ""
+      security_groups: []
+      tags: {}
+      volumes: []
+      vpc_id: ""
+      vpc_subnet_id: ""
+
+    # Merging defaults into a list of dicts is, it turns out, not straightforward
+    platforms: >-
+      {{ [platform_defaults | dict2items]
+           | product(molecule_yml.platforms | map('dict2items') | list)
+           | map('flatten', levels=1)
+           | list
+           | map('items2dict')
+           | list }}
+  pre_tasks:
+    - name: Validate platform configurations
+      ansible.builtin.assert:
+        that:
+          - platforms | length > 0
+          - platform.name is string and platform.name | length > 0
+          - platform.assign_public_ip is boolean
+          - platform.aws_profile is string
+          - platform.boot_wait_seconds is integer and platform.boot_wait_seconds >= 0
+          - platform.cloud_config is mapping
+          - platform.image is string
+          - platform.image_name is string
+          - platform.image_owner is sequence or (platform.image_owner is string and platform.image_owner | length > 0)
+          - platform.instance_type is string and platform.instance_type | length > 0
+          - platform.key_inject_method is in ["cloud-init", "ec2"]
+          - platform.key_name is string and platform.key_name | length > 0
+          - platform.private_key_path is string and platform.private_key_path | length > 0
+          - platform.public_key_path is string and platform.public_key_path | length > 0
+          - platform.region is string
+          - platform.security_group_name is string and platform.security_group_name | length > 0
+          - platform.security_group_description is string and platform.security_group_description | length > 0
+          - platform.security_group_rules is sequence
+          - platform.security_group_rules_egress is sequence
+          - platform.security_groups is sequence
+          - platform.ssh_user is string and platform.ssh_user | length > 0
+          - platform.ssh_port is integer and platform.ssh_port in range(1, 65536)
+          - platform.tags is mapping
+          - platform.volumes is sequence
+          - platform.vpc_id is string
+          - platform.vpc_subnet_id is string and platform.vpc_subnet_id | length > 0
+        quiet: true
+      loop: '{{ platforms }}'
+      loop_control:
+        loop_var: platform
+        label: "{{ platform.name }}"
+  tasks:
+    - name: Write run config to file
+      ansible.builtin.copy:
+        dest: "{{ run_config_path }}"
+        content: "{{ run_config | to_yaml }}"
+        mode: "0600"
+
+    - name: Generate local key pairs
+      community.crypto.openssh_keypair:
+        path: "{{ item.private_key_path }}"
+        type: rsa
+        size: 2048
+        regenerate: never
+        backend: cryptography
+        private_key_format: pkcs1
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: local_keypairs
+
+    - name: Look up EC2 AMI(s) by owner and name (if image not set)
+      amazon.aws.ec2_ami_info:
+        owners: "{{ item.image_owner }}"
+        filters: "{{ item.image_filters | default({}) | combine(image_name_map) }}"
+      vars:
+        image_name_map: "{% if item.image_name is defined and item.image_name | length > 0 %}{{ {'name': item.image_name} }}{% else %}{}{% endif %}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.image
+      register: ami_info
+
+    - name: Look up subnets to determine VPCs (if needed)
+      amazon.aws.ec2_vpc_subnet_info:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.vpc_id
+      register: subnet_info
+
+    - name: Validate discovered information
+      ansible.builtin.assert:
+        that:
+          - platform.image or (ami_info.results[index].images | length > 0)
+          - platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        index_var: index
+        label: "{{ platform.name }}"
+
+    - name: Create ephemeral EC2 keys (if needed)
+      amazon.aws.ec2_key:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        name: "{{ item.key_name }}"
+        key_material: "{{ local_keypair.public_key }}"
+      vars:
+        local_keypair: "{{ local_keypairs.results[index] }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.key_inject_method == "ec2"
+      register: ec2_keys
+
+    - name: Create ephemeral security groups (if needed)
+      amazon.aws.ec2_security_group:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        iam_instance_profile: "{{ item.iam_instance_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+        name: "{{ item.security_group_name }}"
+        description: "{{ item.security_group_description }}"
+        rules: "{{ item.security_group_rules }}"
+        rules_egress: "{{ item.security_group_rules_egress }}"
+      vars:
+        vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.security_groups | length == 0
+
+    - name: Create ephemeral EC2 instance(s)
+      amazon.aws.ec2_instance:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        filters: "{{ platform_filters }}"
+        instance_type: "{{ item.instance_type }}"
+        image_id: "{{ platform_image_id }}"
+        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+        security_groups: "{{ platform_security_groups }}"
+        network:
+          assign_public_ip: "{{ item.assign_public_ip }}"
+        volumes: "{{ item.volumes }}"
+        key_name: "{{ (item.key_inject_method == 'ec2') | ternary(item.key_name, omit) }}"
+        tags: "{{ platform_tags }}"
+        user_data: "{{ platform_user_data }}"
+        state: "running"
+        wait: true
+      vars:
+        platform_security_groups: "{{ item.security_groups or [item.security_group_name] }}"
+        platform_generated_image_id: "{{ (ami_info.results[index].images | sort(attribute='creation_date', reverse=True))[0].image_id }}"
+        platform_image_id: "{{ item.image or platform_generated_image_id }}"
+
+        platform_generated_cloud_config:
+          users:
+            - name: "{{ item.ssh_user }}"
+              ssh_authorized_keys:
+                - "{{ local_keypairs.results[index].public_key }}"
+              sudo: "ALL=(ALL) NOPASSWD:ALL"
+        platform_cloud_config: >-
+          {{ (item.key_inject_method == 'cloud-init')
+               | ternary((item.cloud_config | combine(platform_generated_cloud_config)), item.cloud_config) }}
+        platform_user_data: |-
+          #cloud-config
+          {{ platform_cloud_config | to_yaml }}
+
+        platform_generated_tags:
+          instance: "{{ item.name }}"
+          "molecule-run-id": "{{ run_config.run_id }}"
+        platform_tags: "{{ (item.tags or {}) | combine(platform_generated_tags) }}"
+        platform_filter_keys: "{{ platform_generated_tags.keys() | map('regex_replace', '^(.+)$', 'tag:\\1') }}"
+        platform_filters: "{{ dict(platform_filter_keys | zip(platform_generated_tags.values())) }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      register: ec2_instances_async
+      async: 7200
+      poll: 0
+
+    - name: Instance boot block
+      when: ec2_instances_async is changed
+      block:
+        - name: Wait for instance creation to complete
+          ansible.builtin.async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ec2_instances_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ec2_instances
+          until: ec2_instances is finished
+          retries: 300
+
+        - name: Collect instance configs
+          ansible.builtin.set_fact:
+            instance_config:
+              instance: "{{ item.name }}"
+              address: "{{ item.assign_public_ip | ternary(instance.public_ip_address, instance.private_ip_address) }}"
+              user: "{{ item.ssh_user }}"
+              port: "{{ item.ssh_port }}"
+              identity_file: "{{ item.private_key_path }}"
+              instance_ids:
+                - "{{ instance.instance_id }}"
+          vars:
+            instance: "{{ ec2_instances.results[index].instances[0] }}"
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          register: instance_configs
+
+        - name: Write Molecule instance configs
+          ansible.builtin.copy:
+            dest: "{{ molecule_instance_config }}"
+            content: >-
+              {{ instance_configs.results
+                   | map(attribute='ansible_facts.instance_config')
+                   | list
+                   | to_json
+                   | from_json
+                   | to_yaml }}
+            mode: "0600"
+
+        - name: Start SSH pollers
+          ansible.builtin.wait_for:
+            host: "{{ item.address }}"
+            port: "{{ item.port }}"
+            search_regex: SSH
+            delay: 10
+            timeout: 320
+          loop: "{{ instance_configs.results | map(attribute='ansible_facts.instance_config') | list }}"
+          loop_control:
+            label: "{{ item.instance }}"
+          register: ssh_wait_async
+          async: 300
+          poll: 0
+
+        - name: Wait for SSH
+          ansible.builtin.async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ssh_wait_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ssh_wait
+          until: ssh_wait is finished
+          retries: 300
+          delay: 1
+
+        - name: Wait for boot process to finish
+          ansible.builtin.pause:
+            seconds: "{{ platforms | map(attribute='boot_wait_seconds') | max }}"

--- a/molecule/ec2/destroy.yml
+++ b/molecule/ec2/destroy.yml
@@ -1,0 +1,143 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    # Run config handling
+    default_run_id: "{{ lookup('password', '/dev/null chars=ascii_lowercase length=5') }}"
+    default_run_config:
+      run_id: "{{ default_run_id }}"
+
+    run_config_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/run-config.yml"
+    run_config_from_file: "{{ (lookup('file', run_config_path, errors='ignore') or '{}') | from_yaml }}"
+    run_config: '{{ default_run_config | combine(run_config_from_file) }}'
+
+    # Platform settings handling
+    default_aws_profile: "{{ lookup('env', 'AWS_PROFILE') }}"
+    default_key_inject_method: cloud-init # valid values: [cloud-init, ec2]
+    default_key_name: "molecule-{{ run_config.run_id }}"
+    default_security_group_name: "molecule-{{ run_config.run_id }}"
+
+    platform_defaults:
+      aws_profile: "{{ default_aws_profile }}"
+      key_inject_method: "{{ default_key_inject_method }}"
+      key_name: "{{ default_key_name }}"
+      region: ""
+      security_group_name: "{{ default_security_group_name }}"
+      security_groups: []
+      vpc_id: ""
+      vpc_subnet_id: ""
+
+    # Merging defaults into a list of dicts is, it turns out, not straightforward
+    platforms: >-
+      {{ [platform_defaults | dict2items]
+           | product(molecule_yml.platforms | map('dict2items') | list)
+           | map('flatten', levels=1)
+           | list
+           | map('items2dict')
+           | list }}
+
+    # Stored instance config
+    instance_config: "{{ (lookup('file', molecule_instance_config, errors='ignore') or '{}') | from_yaml }}"
+  pre_tasks:
+    - name: Validate platform configurations
+      ansible.builtin.assert:
+        that:
+          - platforms | length > 0
+          - platform.name is string and platform.name | length > 0
+          - platform.aws_profile is string
+          - platform.key_inject_method is in ["cloud-init", "ec2"]
+          - platform.key_name is string and platform.key_name | length > 0
+          - platform.region is string
+          - platform.security_group_name is string and platform.security_group_name | length > 0
+          - platform.security_groups is sequence
+          - platform.vpc_id is string
+          - platform.vpc_subnet_id is string and platform.vpc_subnet_id | length > 0
+        quiet: true
+      loop: '{{ platforms }}'
+      loop_control:
+        loop_var: platform
+        label: "{{ platform.name }}"
+  tasks:
+    - name: Look up subnets to determine VPCs (if needed)
+      amazon.aws.ec2_vpc_subnet_info:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.vpc_id
+      register: subnet_info
+
+    - name: Validate discovered information
+      ansible.builtin.assert:
+        that: platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        index_var: index
+        label: "{{ platform.name }}"
+
+    - name: Destroy resources
+      when: instance_config | length != 0
+      block:
+        - name: Destroy ephemeral EC2 instances
+          amazon.aws.ec2_instance:
+            profile: "{{ item.aws_profile | default(omit) }}"
+            region: "{{ item.region | default(omit) }}"
+            instance_ids: "{{ instance_config | map(attribute='instance_ids') | flatten }}"
+            vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+            state: absent
+          loop: "{{ platforms }}"
+          loop_control:
+            label: "{{ item.name }}"
+          register: ec2_instances_async
+          async: 7200
+          poll: 0
+
+        - name: Wait for instance destruction to complete
+          ansible.builtin.async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ec2_instances_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ec2_instances
+          until: ec2_instances is finished
+          retries: 300
+
+        - name: Destroy ephemeral security groups (if needed)
+          amazon.aws.ec2_security_group:
+            profile: "{{ item.aws_profile | default(omit) }}"
+            region: "{{ item.region | default(omit) }}"
+            vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+            name: "{{ item.security_group_name }}"
+            state: absent
+          vars:
+            vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          when: item.security_groups | length == 0
+
+        - name: Destroy ephemeral keys (if needed)
+          amazon.aws.ec2_key:
+            profile: "{{ item.aws_profile | default(omit) }}"
+            region: "{{ item.region | default(omit) }}"
+            name: "{{ item.key_name }}"
+            state: absent
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          when: item.key_inject_method == "ec2"
+
+        - name: Write Molecule instance configs
+          ansible.builtin.copy:
+            dest: "{{ molecule_instance_config }}"
+            content: "{{ {} | to_yaml }}"

--- a/molecule/ec2/molecule.yml
+++ b/molecule/ec2/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+platforms:
+  - name: instance
+    image: "${AWS_AMI_ID}"
+    instance_type: "${AWS_INSTANCE_TYPE}"
+    ssh_user: molecule
+    vpc_subnet_id: "${AWS_VPC_SUBNET_ID}"
+    region: "${AWS_REGION}"
+    tags:
+      Name: molecule_instance
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/ec2/prepare.yml
+++ b/molecule/ec2/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Make sure python3 is installed
+      ansible.builtin.package:
+        name: python3
+        state: present
+      become: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+git+https://github.com/ansible/molecule@main#egg=molecule
+#molecule==25.4.0
+ansible-core
+molecule-plugins[ec2]
+boto3
+ansible-doctor

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Say hello
+  ansible.builtin.debug:
+    msg: "hello world!"

--- a/test_requirements.yml
+++ b/test_requirements.yml
@@ -1,0 +1,8 @@
+---
+collections:
+  - name: community.crypto
+    version: 2.26.2
+  - name: amazon.aws
+    version: 9.5.0
+
+

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - juno_k3s

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for juno_k3s


### PR DESCRIPTION
This sets up the initial dev tooling for testing&autodocs. I am already bumping it as a PR to make next reviews easier.

The docs here are conforming to a more ansible-style convention.

This is because the role in this repo is a component that the playbook repo will import (https://github.com/juno-fx/k8s-playbooks).

The more high-level usage docs will stil be following the Orion doc convention and will be added on the other repo.

This also sets up the CI and runs test against each Linux distirbution we support.
The test works like this: we spin up the EC2 instances needed to apply
our example playbook -> we apply it -> we note down the result in CI and
tear it down.

It cleans up even after failures, so we won't incur big
cost.


Details on the AWS-side conf are in: https://github.com/juno-fx/juno_k3s_private/issues/1