### PR TITLE
Set up an airgapped Juno-Bootstrap installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export AWS_INSTANCE_TYPE ?= t2.large
 
 venv/bin/activate:
 	python3 -m venv venv
-	. venv/bin/activate; pip install -r requirements.txt
+	. venv/bin/activate; python3 -m pip install -r requirements.txt
 	. venv/bin/activate; ansible-galaxy install -r test_requirements.yml
 
 docs: venv/bin/activate
@@ -23,13 +23,24 @@ docs: venv/bin/activate
 	sed -i '$$a{% endraw %}' docs/readme/molecule_converge_online_escaped.yml
 	sed -i '1s/^/{% raw %}\n/' docs/readme/molecule_converge_airgapped_escaped.yml
 	sed -i '$$a{% endraw %}' docs/readme/molecule_converge_airgapped_escaped.yml
+	sed -i '/### BEGIN-TEST-ONLY ###/,/### END-TEST-ONLY ###/d' docs/readme/molecule_converge_online_escaped.yml
+	sed -i '/### BEGIN-TEST-ONLY ###/,/### END-TEST-ONLY ###/d' docs/readme/molecule_converge_airgapped_escaped.yml
 	ansible-doctor
 
 login-%: venv/bin/activate
 	. venv/bin/activate; venv/bin/molecule login -s ec2 --host k8s_${*}
 
+login-airgap-%: venv/bin/activate
+	. venv/bin/activate; venv/bin/molecule login -s ec2-airgap --host k8s_${*}
+
+login-airgap-proxy: venv/bin/activate
+	. venv/bin/activate; venv/bin/molecule login -s ec2-airgap --host airgap_proxy
+
 converge-airgap-%: venv/bin/activate
 	. venv/bin/activate; AWS_AMI_ID=${$*_AMI} venv/bin/molecule converge -s ec2-airgap
+
+prepare-airgap-%: venv/bin/activate
+	. venv/bin/activate; AWS_AMI_ID=${$*_AMI} venv/bin/molecule prepare -f -s ec2-airgap
 
 test-airgap-%: venv/bin/activate
 	. venv/bin/activate; AWS_AMI_ID=${$*_AMI} venv/bin/molecule test -s ec2-airgap
@@ -76,3 +87,7 @@ login-control_plane01: login-control_plane01
 login-control_plane02: login-control_plane02
 login-control_plane03: login-control_plane03
 login-worker01: login-worker01
+login-airgap-control_plane01: login-airgap-control_plane01
+login-airgap-control_plane02: login-airgap-control_plane02
+login-airgap-control_plane03: login-airgap-control_plane03
+login-airgap-worker01: login-airgap-worker01

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # juno_k3s
 
-your role description
+A role deploying k3s&bootstrapping [Juno Innovations Orion](https://www.juno-innovations.com/)
+Supporting both airgapped and online environments
+
 
 ## Table of content
 
@@ -16,19 +18,34 @@ your role description
 ## Role variables
 | Name | Default value | Description |
 |:-----|:--------------|:------------|
-| k3s_airgap_install |  | ['  If true, the playbook will perform an airgapped install. Make sure all the URLs above are set to file:// or point to a local mirror.', '  When setting the URLs to file://, they will be copied from your Ansible control host to the remote hosts.'] |
-| k3s_binary_url |  | ['  URL for the k3s binary. Can be http://, https:// OR file://', '  When using file://, a path from your ansible control host (where your run the playbook from) will be used.', '  The files will be copied to the remote kubernetes hosts. This is useful for airgap installs.'] |
-| k3s_bootstrap_node |  | ['  The node used to bootstrap the cluster. This should only ever be a single node in your inventory!', '  The playbook example we provide discovers this dynamically, but you can also set it manually.'] |
-| k3s_bootstrap_node_ip |  | ['  The IP address of an existing controlplane node, used to join the cluster.', '  In most cases, we can automatically discover this, check out the playbook example - it does that out of the box!'] |
-| k3s_clusterjoin_address |  | ['The address of the cluster to join. Can only be false when k3s_bootstrap_node is true.'] |
-| k3s_control_plane_node |  | ['  When true, join the node to an existing cluster as a control plane node.', '  When neither k3s_bootstrap_node nor k3s_control_plane_node is true, the node will be a worker node.'] |
-| k3s_force_reinstall |  | ['  If true, rerun the k3s install script even if the node is already part of a cluster.'] |
-| k3s_images_url |  | ['  URL for the k3s images tarball. Can be http://, https:// OR file://', '  When using file://, a path from your ansible control host (where your run the playbook from) will be used.', '  The files will be copied to the remote kubernetes hosts. This is useful for airgap installs.'] |
-| k3s_install_script_url |  | ['  URL for the k3s install script. Can be http://, https:// OR file://', '  When using file://, a path from your ansible control host (where your run the playbook from) will be used.', '  The files will be copied to the remote kubernetes hosts. This is useful for airgap installs.'] |
-| k3s_join_token |  | ['  The token used to join the cluster. You can specify it explicitly or let the playbook autodiscover it.', '  Check out the example playbook for how to do that.', 'k3s_join_token: false'] |
-| k3s_registries_yaml |  | ['  If true, the playbook will configure the registries.yaml file to use your internal mirror.', '  For syntax refer to https://docs.k3s.io/installation/private-registry', '  The data you pass in here will be DIRECTLY templated into the registries.yaml file.'] |
-| k3s_uninstall |  | ['  If true, the playbook will run the default uninstall script (/usr/local/bin/k3s-uninstall.sh)', "  This is intended mostly for quick testing - in production, ideally you'd reprovision freshly."] |
-| validate_os_version |  | ['Check we are on a supported OS version, error otherwise.'] |
+| argo_install_manifest_url | https://raw.githubusercontent.com/argoproj/argo-cd/v3.0.9/manifests/install.yaml |  The URL of the ArgoCD install manifest. This can be a file://, http:// or https:// URL.  If you use file://, the file will be copied from your Ansible control host to the remote hosts. |
+| juno_bootstrap_chart_repo_revision | main |  The revision of the Juno-Bootstrap repository to use. This can be a branch name, tag or commit hash. |
+| juno_bootstrap_chart_values | {} |  Values to pass to the Juno Bootstrap chart. See: https://github.com/juno-fx/Juno-Bootstrap If you do not use a direct OCI proxy and leverage the k3s_registries_yaml var, you also could need to adjust the repository from which to pull images. For details, see: https://github.com/juno-fx/Juno-Bootstrap and the example airgapped playbook. |
+| juno_bootstrap_git_password | {{ juno_git_password }} | This authenticates only the Juno-Bootstrap repository. You can leave it unchanged if both Juno-Bootstrap and Genesis-Deployment are accessible via juno_git_username&juno_git_password. |
+| juno_bootstrap_git_url | https://github.com/juno-fx/Juno-Bootstrap.git |  The URL of the Juno-Bootstrap repository. This only needs to be adjusted if you forked it or are using an airgapped environment. |
+| juno_bootstrap_git_username | {{ juno_git_username }} |  This authenticates only the Juno-Bootstrap repository. You can leave it unchanged if both Juno-Bootstrap and Genesis-Deployment are accessible via juno_git_username&juno_git_password. |
+| juno_genesis_deployment_git_password | {{ juno_git_password }} |  This authenticates only the Juno Genesis Deployment repository. You can leave it unchanged if |
+| juno_genesis_deployment_git_url | https://github.com/juno-fx/Genesis-Deployment.git |  The URL of the Genesis-Deployment repository. Note you still need to set the juno_bootstrap_chart_values.genesis.url value to point to the Genesis-Deployment repository.  This argument is only used to create the git sercet. It can be left empty on a default, non-airgapped install. |
+| juno_genesis_deployment_git_username | {{ juno_git_username }} |  This authenticates only the Juno Genesis Deployment repository. You can leave it unchanged if both Juno-Bootstrap and Genesis-Deployment are accessible via juno_git_username&juno_git_password. |
+| juno_git_password | False |  The password used to authenticate with all Juno repositories you specified. If left to the default (false), a public repository is assumed. |
+| juno_git_username | oauth2 |  The username used to authenticate with all Juno repositories you specified. This is needed when you use a private fork of the Juno Bootstrap repository.  It is particularly useful in airgapped environments, where you might neither have access to the public version and might require authentication on your Git host. |
+| juno_install | True |  Bootstrap Juno's Orion using https://github.com/juno-fx/Juno-Bootstrap |
+| k3s_airgap_install | False |  If true, the playbook will perform an airgapped install. Make sure all the URLs above are set to file:// or point to a local mirror.  When setting the URLs to file://, they will be copied from your Ansible control host to the remote hosts. |
+| k3s_binary_url | https://github.com/k3s-io/k3s/releases/download/v1.33.1%2Bk3s1/k3s |  URL for the k3s binary. Can be http://, https:// OR file://  When using file://, a path from your ansible control host (where your run the playbook from) will be used.  The files will be copied to the remote kubernetes hosts. This is useful for airgap installs. |
+| k3s_bootstrap_node | False |  The node used to bootstrap the cluster. This should only ever be a single node in your inventory!  The playbook example we provide discovers this dynamically, but you can also set it manually. |
+| k3s_bootstrap_node_ip | False |  The IP address of an existing controlplane node, used to join the cluster.  In most cases, we can automatically discover this, check out the playbook example - it does that out of the box! |
+| k3s_clusterjoin_address | False |The address of the cluster to join. Can only be false when k3s_bootstrap_node is true. |
+| k3s_control_plane_node | False |  When true, join the node to an existing cluster as a control plane node.  When neither k3s_bootstrap_node nor k3s_control_plane_node is true, the node will be a worker node. |
+| k3s_copy_images | {{ k3s_airgap_install and not k3s_registries_yaml }} |  If true, the role will copy the k3s images tarball to the standard location where k3s can load them.  By default, we don't perform this if you define registries.yaml, as it is assumed you will have a local mirror. |
+| k3s_force_reinstall | False |  If true, rerun the k3s install script even if the node is already part of a cluster. |
+| k3s_images_url | https://github.com/k3s-io/k3s/releases/download/v1.33.1%2Bk3s1/k3s-airgap-images-amd64.tar.gz |  URL for the k3s images tarball. Can be http://, https:// OR file://  When using file://, a path from your ansible control host (where your run the playbook from) will be used.  The files will be copied to the remote kubernetes hosts. This is useful for airgap installs. |
+| k3s_install_script_url | https://get.k3s.io/ |  URL for the k3s install script. Can be http://, https:// OR file://  When using file://, a path from your ansible control host (where your run the playbook from) will be used.  The files will be copied to the remote kubernetes hosts. This is useful for airgap installs. |
+| k3s_join_token |  |  The token used to join the cluster. You can specify it explicitly or let the playbook autodiscover it.  Check out the example playbook for how to do that.k3s_join_token: false |
+| k3s_node_labels | ["{{ k3s_control_plane_node | ternary('juno-innovations.com/service=true', 'juno-innovations.com/workstation=true') }}"] |  A list of labels to apply to a node on provisioning, only when k3s_perform_node_labeling is true.  Defaults to making each control plane node a Juno service node and each worker node a workstation node.  For details on how labels affect your Orion deployment, check out: https://juno-fx.github.io/Orion-Documentation/installation/pre-reqs/requirements/?h=label#1-labeling-nodes |
+| k3s_perform_node_labeling | True |  Whether to label nodes when performing the initial k3s install.  Already existing nodes will not be labeled - use kubectl instead, per: https://juno-fx.github.io/Orion-Documentation/installation/pre-reqs/requirements/?h=label#1-labeling-nodes |
+| k3s_registries_yaml | False |  If true, the playbook will configure the registries.yaml file to use your internal mirror.  For syntax refer to https://docs.k3s.io/installation/private-registry  The data you pass in here will be directly templated into the registries.yaml file. |
+| k3s_uninstall | False |  If true, the playbook will run the default uninstall script (/usr/local/bin/k3s-uninstall.sh)  This is intended mostly for quick testing - in production, ideally you'd reprovision freshly. |
+| validate_os_version | True |Check we are on a supported OS version, error otherwise. |
 
 
 
@@ -132,13 +149,36 @@ You can check the detailed information for each file in the vars section above.
 ```yaml
 
 ---
+
 - name: Ensure the correct state of all nodes in the cluster
-  hosts: all
+  hosts:
+    - control_plane
+    - k8s_worker
   vars:
+    juno_git_user: "oauth2"
+    juno_git_password: "password"
+    juno_genesis_deployment_git_url: "http://{{ proxy_address }}/git/Genesis-Deployment.git"
+    argo_install_manifest_url: "file://{{ playbook_dir }}/airgap_files/argo-install.yaml"
+    juno_bootstrap_git_url: "http://{{ proxy_address }}/git/Juno-Bootstrap.git"
     k3s_install_script_url: "file://{{ playbook_dir }}/airgap_files/install.sh"
     k3s_binary_url: "file://{{ playbook_dir }}/airgap_files/k3s"
-    k3s_images_url: "file://{{ playbook_dir }}/airgap_files/k3s-airgap-images-amd64.tar.zst"
+    # For more details on using a private registry, eg. using authentication, see:
+    # https://docs.k3s.io/installation/private-registry
+    k3s_registries_yaml: |
+      mirrors:
+        docker.io:
+          endpoint:
+            - "http://{{ proxy_address }}:5000"
+        quay.io:
+          endpoint:
+            - "http://{{ proxy_address }}:5001"
+        ghcr.io:
+          endpoint:
+            - "http://{{ proxy_address }}:5002"
     k3s_airgap_install: true
+    juno_bootstrap_chart_values:
+      genesis:
+        repoURL: "http://{{ proxy_address }}/git/Genesis-Deployment.git"
   tasks:
     - name: Check if the join token file exists
       ansible.builtin.stat:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,10 +53,76 @@ k3s_force_reinstall: false
 # @var k3s_registries_yaml:description: >
 #   If true, the playbook will configure the registries.yaml file to use your internal mirror.
 #   For syntax refer to https://docs.k3s.io/installation/private-registry
-#   The data you pass in here will be DIRECTLY templated into the registries.yaml file.
+#   The data you pass in here will be directly templated into the registries.yaml file.
 k3s_registries_yaml: false
 
 # @var k3s_uninstall:description: >
 #   If true, the playbook will run the default uninstall script (/usr/local/bin/k3s-uninstall.sh)
 #   This is intended mostly for quick testing - in production, ideally you'd reprovision freshly.
 k3s_uninstall: false
+
+# @var juno_install:description: >
+#   Bootstrap Juno's Orion using https://github.com/juno-fx/Juno-Bootstrap
+juno_install: true
+
+# @var argo_install_manifest_url:description: >
+#   The URL of the ArgoCD install manifest. This can be a file://, http:// or https:// URL.
+#   If you use file://, the file will be copied from your Ansible control host to the remote hosts.
+argo_install_manifest_url: https://raw.githubusercontent.com/argoproj/argo-cd/v3.0.9/manifests/install.yaml
+
+# @var juno_bootstrap_git_url:description: >
+#   The URL of the Juno-Bootstrap repository. This only needs to be adjusted if you forked it or are using an airgapped environment.
+juno_bootstrap_git_url: "https://github.com/juno-fx/Juno-Bootstrap.git"
+# @var juno_bootstrap_chart_repo_revision:description: >
+#   The revision of the Juno-Bootstrap repository to use. This can be a branch name, tag or commit hash.
+juno_bootstrap_chart_repo_revision: "main"
+
+# @var juno_genesis_deployment_git_url:description: >
+#   The URL of the Genesis-Deployment repository. Note you still need to set the juno_bootstrap_chart_values.genesis.url value to point to the Genesis-Deployment repository.
+#   This argument is only used to create the git sercet. It can be left empty on a default, non-airgapped install.
+juno_genesis_deployment_git_url: "https://github.com/juno-fx/Genesis-Deployment.git"
+
+# @var juno_bootstrap_chart_values:description: >
+#   Values to pass to the Juno Bootstrap chart. See: https://github.com/juno-fx/Juno-Bootstrap
+#  If you do not use a direct OCI proxy and leverage the k3s_registries_yaml var, you also could need to adjust the repository from which to pull images.
+#  For details, see: https://github.com/juno-fx/Juno-Bootstrap and the example airgapped playbook.
+juno_bootstrap_chart_values: {}
+
+# @var juno_git_username:description: >
+#   The username used to authenticate with all Juno repositories you specified. This is needed when you use a private fork of the Juno Bootstrap repository.
+#   It is particularly useful in airgapped environments, where you might neither have access to the public version and might require authentication on your Git host.
+juno_git_username: oauth2
+# @var juno_git_password:description: >
+#   The password used to authenticate with all Juno repositories you specified. If left to the default (false), a public repository is assumed.
+juno_git_password: false
+
+# @var juno_bootstrap_git_username:description: >
+#   This authenticates only the Juno-Bootstrap repository. You can leave it unchanged if both Juno-Bootstrap and Genesis-Deployment are accessible via juno_git_username&juno_git_password.
+juno_bootstrap_git_username: "{{ juno_git_username }}"
+# @var juno_bootstrap_git_password:description: >
+#  This authenticates only the Juno-Bootstrap repository. You can leave it unchanged if both Juno-Bootstrap and Genesis-Deployment are accessible via juno_git_username&juno_git_password.
+juno_bootstrap_git_password: "{{ juno_git_password }}"
+
+# @var juno_genesis_deployment_git_username:description: >
+#   This authenticates only the Juno Genesis Deployment repository. You can leave it unchanged if both Juno-Bootstrap and Genesis-Deployment are accessible via juno_git_username&juno_git_password.
+juno_genesis_deployment_git_username: "{{ juno_git_username }}"
+# @var juno_genesis_deployment_git_password:description: >
+#   This authenticates only the Juno Genesis Deployment repository. You can leave it unchanged if
+juno_genesis_deployment_git_password: "{{ juno_git_password }}"
+
+# @var k3s_perform_node_labeling:description: >
+#   Whether to label nodes when performing the initial k3s install.
+#   Already existing nodes will not be labeled - use kubectl instead, per: https://juno-fx.github.io/Orion-Documentation/installation/pre-reqs/requirements/?h=label#1-labeling-nodes
+k3s_perform_node_labeling: true
+
+# @var k3s_node_labels:description: >
+#   A list of labels to apply to a node on provisioning, only when k3s_perform_node_labeling is true.
+#   Defaults to making each control plane node a Juno service node and each worker node a workstation node.
+#   For details on how labels affect your Orion deployment, check out: https://juno-fx.github.io/Orion-Documentation/installation/pre-reqs/requirements/?h=label#1-labeling-nodes
+k3s_node_labels:
+  - "{{ k3s_control_plane_node | ternary('juno-innovations.com/service=true', 'juno-innovations.com/workstation=true') }}"
+
+# @var k3s_copy_images:description: >
+#   If true, the role will copy the k3s images tarball to the standard location where k3s can load them.
+#   By default, we don't perform this if you define registries.yaml, as it is assumed you will have a local mirror.
+k3s_copy_images: "{{ k3s_airgap_install and not k3s_registries_yaml }}"

--- a/docs/readme/_vars.j2
+++ b/docs/readme/_vars.j2
@@ -4,6 +4,6 @@
 ## Role variables
 | Name | Default value | Description |
 |:-----|:--------------|:------------|
-{% for key, item in var | dictsort %}| {{ key }} | {{ item.default | default('') }} | {{ item.description | default('') }} |
+{% for key, item in var | dictsort %}| {{ key }} | {{ item.value[key] | default('') if item.value is defined else '' }} |{{ item.description | default([]) | join('') }} |
 {% endfor %}
 {% endif %}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,9 @@ galaxy_info:
   role_name: juno_k3s
   author: Juno Innovations
   namespace: juno-fx
-  description: your role description
+  description: |
+    A role deploying k3s&bootstrapping [Juno Innovations Orion](https://www.juno-innovations.com/)
+    Supporting both airgapped and online environments
   company: Juno Innovations
 
   license: Apache-2.0

--- a/molecule/ec2-airgap/converge.yml
+++ b/molecule/ec2-airgap/converge.yml
@@ -1,11 +1,45 @@
 ---
-- name: Ensure the correct state of all nodes in the cluster
+### BEGIN-TEST-ONLY ###
+# sed is used to replace the above out from the readme we render and make it more readable
+- name: Get the IP of the airgap-proxy using ec2_instance_facts
   hosts: all
+  gather_facts: true
+  tasks:
+    - name: Set the IP address of airgap proxy as proxy_address for all hosts
+      ansible.builtin.set_fact:
+        proxy_address: "{{ hostvars['airgap_proxy'].ansible_default_ipv4.address }}"
+      when: inventory_hostname != 'airgap_proxy'
+### END-TEST-ONLY ###
+
+- name: Ensure the correct state of all nodes in the cluster
+  hosts:
+    - control_plane
+    - k8s_worker
   vars:
+    juno_git_user: "oauth2"
+    juno_git_password: "password"
+    juno_genesis_deployment_git_url: "http://{{ proxy_address }}/git/Genesis-Deployment.git"
+    argo_install_manifest_url: "file://{{ playbook_dir }}/airgap_files/argo-install.yaml"
+    juno_bootstrap_git_url: "http://{{ proxy_address }}/git/Juno-Bootstrap.git"
     k3s_install_script_url: "file://{{ playbook_dir }}/airgap_files/install.sh"
     k3s_binary_url: "file://{{ playbook_dir }}/airgap_files/k3s"
-    k3s_images_url: "file://{{ playbook_dir }}/airgap_files/k3s-airgap-images-amd64.tar.zst"
+    # For more details on using a private registry, eg. using authentication, see:
+    # https://docs.k3s.io/installation/private-registry
+    k3s_registries_yaml: |
+      mirrors:
+        docker.io:
+          endpoint:
+            - "http://{{ proxy_address }}:5000"
+        quay.io:
+          endpoint:
+            - "http://{{ proxy_address }}:5001"
+        ghcr.io:
+          endpoint:
+            - "http://{{ proxy_address }}:5002"
     k3s_airgap_install: true
+    juno_bootstrap_chart_values:
+      genesis:
+        repoURL: "http://{{ proxy_address }}/git/Genesis-Deployment.git"
   tasks:
     - name: Check if the join token file exists
       ansible.builtin.stat:

--- a/molecule/ec2-airgap/molecule.yml
+++ b/molecule/ec2-airgap/molecule.yml
@@ -6,6 +6,55 @@ driver:
 # security groups cannot be defined outside one of those items - so they must live in the list here.
 # Not the cleanest, but necessary.
 platforms:
+  - name: airgap_proxy
+    groups:
+      - airgap_proxy
+    image: "${AWS_AMI_ID}"
+    instance_type: "${AWS_INSTANCE_TYPE}"
+    ssh_user: molecule
+    vpc_subnet_id: "${AWS_VPC_SUBNET_ID}"
+    region: "${AWS_REGION}"
+    tags:
+      Name: molecule_k8s_worker01
+      molecule: true
+    security_group_name: molecule-juno_k3s-airgap-proxy
+    security_group_rules:
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: "0.0.0.0/0"
+        # mock git server to host "forks" of Juno-Bootstrap and Genesis-Deployment
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: "10.0.0.0/8"
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: "172.16.0.0/12"
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: "192.168.0.0/16"
+      # docker registry cache
+      - proto: tcp
+        from_port: 5000
+        to_port: 5002
+        cidr_ip: "10.0.0.0/8"
+      - proto: tcp
+        from_port: 5000
+        to_port: 5002
+        cidr_ip: "172.16.0.0/12"
+      - proto: tcp
+        from_port: 5000
+        to_port: 5002
+        cidr_ip: "192.168.0.0/16"
+    security_group_rules_egress:
+      - proto: -1
+        from_port: 0
+        to_port: 0
+        cidr_ip: "0.0.0.0/0"
+
   - name: k8s_control_plane01
     groups:
       - control_plane

--- a/molecule/ec2-airgap/prepare.yml
+++ b/molecule/ec2-airgap/prepare.yml
@@ -1,4 +1,231 @@
 ---
+# Notes on setting up a git host: https://gist.github.com/Kreijstal/28fc987270b71849505bbc89b3f2d90a
+# ToDo: add nvcr.io if we start testing GPU workloads within molecule/reproducing any bugs related to them
+- name: Prepare the airgap-proxy host, simulating an airgapped env's local git&OCI repositories
+  hosts: airgap_proxy
+  gather_facts: true
+  tasks:
+    - name: Install packages needed to mimick an airgapped environment
+      ansible.builtin.package:
+        update_cache: true
+        name:
+          - podman
+          - nginx
+          - git
+          # used for git-http-backend
+          - fcgiwrap
+          # provides htpasswd
+          - "{{ 'apache2-utils' if ansible_os_family == 'Debian' else 'httpd-tools' }}"
+        state: present
+      become: true
+    - name: Create /srv/git
+      become: true
+      ansible.builtin.file:
+        owner: www-data
+        path: /srv/git
+        state: directory
+
+    - name: Start up fcgiwrap
+      become: true
+      ansible.builtin.systemd:
+        name: fcgiwrap
+        state: started
+        enabled: true
+
+    - name: Clone down Juno-Bootstrap to /srv/git/Juno-Bootstrap
+      become: true
+      failed_when: false
+      ansible.builtin.git:
+        repo: https://github.com/juno-fx/Juno-Bootstrap.git
+        dest: /srv/git/Juno-Bootstrap.git
+        version: "main"
+        force: true
+        update: true
+        accept_hostkey: true
+        clone: true
+
+    - name: Clone down the Genesis Deployment repo to /srv/git/Genesis-Deployment
+      become: true
+      ansible.builtin.git:
+        repo: https://github.com/juno-fx/Genesis-Deployment.git
+        dest: /srv/git/Genesis-Deployment.git
+        version: "v1.1"
+        force: true
+        update: true
+        accept_hostkey: true
+
+    - name: Set ownership on /srv/git recursively to www-data
+      become: true
+      ansible.builtin.file:
+        path: /srv/git
+        owner: www-data
+        group: www-data
+        mode: "0755"
+        state: directory
+        recurse: true
+
+    - name: Adjust nginx conf to serve the git repos with username:password basic auth
+      become: true
+      ansible.builtin.copy:
+        dest: /etc/nginx/nginx.conf
+        mode: "0644"
+        owner: root
+        group: root
+        content: |
+          user www-data;
+          worker_processes auto;
+          pid /run/nginx.pid;
+          error_log /var/log/nginx/error.log;
+          include /etc/nginx/modules-enabled/*.conf;
+
+          events {
+          	worker_connections 768;
+          	# multi_accept on;
+          }
+
+          http {
+          	sendfile on;
+          	tcp_nopush on;
+          	types_hash_max_size 2048;
+
+          	include /etc/nginx/mime.types;
+          	default_type application/octet-stream;
+
+          	access_log /var/log/nginx/access.log;
+
+          	gzip on;
+          	server {
+          		 listen 80 default_server;
+          	    set $git_root /srv/git;
+          		  # Serve Git repositories under /git/
+          		  location ~ ^/git/([^/]+\.git)(/.*)?$ {
+          		    include fastcgi_params;
+          		    fastcgi_param SCRIPT_FILENAME /usr/lib/git-core/git-http-backend;
+          		    fastcgi_param GIT_PROJECT_ROOT $git_root;
+          			  fastcgi_param GIT_HTTP_EXPORT_ALL "1"; # Allow access without git-daemon-export-ok
+          			  fastcgi_param PATH_INFO /$1$2; # Repo name + subpath (e.g., /myrepo.git/info/refs)
+          			  fastcgi_param REQUEST_METHOD $request_method;
+          			  fastcgi_param QUERY_STRING $query_string;
+          			  fastcgi_pass unix:/var/run/fcgiwrap.socket;
+                }
+             }
+          }
+
+
+    - name: Create the nginx htpasswd file
+      become: true
+      ansible.builtin.command:
+        cmd: htpasswd -cb /etc/nginx/.htpasswd oauth2 password
+        creates: /etc/nginx/.htpasswd
+
+    - name: Reload nginx
+      become: true
+      ansible.builtin.systemd:
+        name: nginx
+        state: reloaded
+
+    - name: Create /opt/dockerhub_mirror/etc/docker/registry
+      become: true
+      ansible.builtin.file:
+        path: /opt/dockerhub_mirror/etc/docker/registry
+        state: directory
+
+    - name: Create /opt/quay_io_mirror/etc/docker/registry
+      become: true
+      ansible.builtin.file:
+        path: /opt/quay_io_mirror/etc/docker/registry
+        state: directory
+    
+    - name: Create /opt/ghcr_io_mirror/etc/docker/registry
+      become: true
+      ansible.builtin.file:
+        path: /opt/ghcr_io_mirror/etc/docker/registry
+        state: directory
+
+    - name: Write in the contents of /opt/dockerhub_mirror/etc/docker/registry/config.yml
+      become: true
+      ansible.builtin.copy:
+        dest: /opt/dockerhub_mirror/etc/docker/registry/config.yml
+        mode: "0644"
+        owner: root
+        group: root
+        # ToDo: add a test case for auth-enabled registries
+        content: |
+          version: 0.1
+          proxy:
+           remoteurl: https://registry-1.docker.io
+          storage:
+            filesystem:
+              rootdirectory: /var/lib/registry
+          http:
+            addr: 0.0.0.0:5000
+
+    - name: Write in the contents of /opt/quay_io_mirror/etc/docker/registry/config.yml
+      become: true
+      ansible.builtin.copy:
+        dest: /opt/quay_io_mirror/etc/docker/registry/config.yml
+        mode: "0644"
+        owner: root 
+        group: root
+        content: |
+          version: 0.1
+          proxy:
+           remoteurl: https://quay.io
+          storage:
+            filesystem:
+              rootdirectory: /var/lib/registry
+          http:
+            addr: 0.0.0.0:5000
+
+    - name: Write in the contents of /opt/ghcr_io_mirror/etc/docker/registry/config.yml
+      become: true
+      ansible.builtin.copy:
+        dest: /opt/ghcr_io_mirror/etc/docker/registry/config.yml
+        mode: "0644"
+        owner: root 
+        group: root
+        content: |
+          version: 0.1
+          proxy:
+           remoteurl: https://ghcr.io
+          storage:
+            filesystem:
+              rootdirectory: /var/lib/registry
+          http:
+            addr: 0.0.0.0:5000
+
+    - name: Spin up a pull-through OCI registry container, pointed to dockerhub
+      become: true
+      containers.podman.podman_container:
+        name: oci-registry
+        image: registry:2
+        volumes:
+          - /opt/dockerhub_mirror/etc/docker/registry:/etc/docker/registry
+        state: started
+        ports:
+          - "5000:5000"
+
+    - name: Spin up a pull-through OCI registry container, pointed to quay.io
+      become: true
+      containers.podman.podman_container:
+        name: quay-oci-registry
+        image: registry:2
+        volumes:
+          - /opt/quay_io_mirror/etc/docker/registry:/etc/docker/registry
+        state: started
+        ports:
+          - "5001:5000"
+    - name: Spin up a pull-through OCI registry container, pointed to ghcr.io
+      become: true
+      containers.podman.podman_container:
+        name: ghcr-oci-registry
+        image: registry:2
+        volumes:
+          - /opt/ghcr_io_mirror/etc/docker/registry:/etc/docker/registry
+        state: started
+        ports:
+          - "5002:5000"
+
 # This contains all the prereqs we expect the user to perform before an airgap install
 - name: Gather airgap install files the user would place on the host on their own
   hosts: localhost
@@ -18,10 +245,10 @@
         url: "https://github.com/k3s-io/k3s/releases/download/v1.33.1%2Bk3s1/k3s"
         dest: "{{ playbook_dir }}/airgap_files/k3s"
         mode: "0644"
-    - name: Download the k3s images to the airgap_files directory
+    - name: Download the argo deployment manifests
       ansible.builtin.get_url:
-        url: "https://github.com/k3s-io/k3s/releases/download/v1.33.1%2Bk3s1/k3s-airgap-images-amd64.tar.zst"
-        dest: "{{ playbook_dir }}/airgap_files/k3s-airgap-images-amd64.tar.zst"
+        url: "https://raw.githubusercontent.com/argoproj/argo-cd/v3.0.9/manifests/install.yaml"
+        dest: "{{ playbook_dir }}/airgap_files/argo-install.yaml"
         mode: "0644"
 
 - name: Prepare k8s hosts
@@ -41,3 +268,4 @@
         cmd: setenforce 0
       when: "'selinux' in ansible_facts.services"
       become: true
+

--- a/tasks/juno_install.yml
+++ b/tasks/juno_install.yml
@@ -1,0 +1,96 @@
+---
+- name: Create the argocd namespace
+  become: true
+  ansible.builtin.command:
+    cmd: /usr/local/bin/k3s kubectl create namespace argocd 
+  register: argocd_namespace_result
+  failed_when: argocd_namespace_result.rc != 0 and('already exists' not in argocd_namespace_result.stderr)
+  changed_when: argocd_namespace_result.rc == 0
+
+- name: Download the argo deployment manifest (http/https)
+  when: argo_install_manifest_url.startswith('http://') or argo_install_manifest_url.startswith('https://')
+  become: true
+  ansible.builtin.get_url:
+    dest: /tmp/argo-install.yaml
+    url: "{{ argo_install_manifest_url }}"
+    mode: "0640"
+    owner: root
+    group: root
+
+- name: Download the argo deployment manifest (file)
+  when: argo_install_manifest_url.startswith('file://')
+  become: true
+  ansible.builtin.copy:
+    src: "{{ argo_install_manifest_url | regex_replace('^file://', '') }}"
+    dest: /tmp/argo-install.yaml
+    mode: "0640"
+    owner: root
+    group: root
+
+# We use raw kubectl instead of kubernetes.core.k8s to avoid python dependencies on the host
+- name: Deploy argo using kubectl
+  become: true
+  ansible.builtin.command:
+    cmd: /usr/local/bin/k3s kubectl apply -f /tmp/argo-install.yaml --namespace argocd 
+  register: argo_deploy_result
+  failed_when: argo_deploy_result.rc != 0 and "'already exists' not in argo_deploy_result.stderr"
+  changed_when: "('created' in argo_deploy_result.stdout) and argo_deploy_result.rc == 0"
+
+- name: Add credentials for juno bootstrap via kubectl raw input
+  become: true
+  ansible.builtin.command:
+    cmd: /usr/local/bin/k3s kubectl apply -f - --namespace argocd
+  args:
+    stdin: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: juno-bootstrap-repo-secret
+        namespace: argocd
+        labels:
+          argocd.argoproj.io/secret-type: repository
+      stringData:
+        type: git
+        url: "{{ juno_bootstrap_git_url }}"
+        password: "{{ juno_bootstrap_git_password }}"
+        username: "{{ juno_bootstrap_git_username }}"
+  when: juno_bootstrap_git_password
+
+- name: Add credentials for Genesis-Deployment
+  become: true
+  when: juno_genesis_deployment_git_password
+  register: juno_genesis_deployment_git_password
+  ansible.builtin.command:
+    cmd: /usr/local/bin/k3s kubectl apply -f - --namespace argocd
+  args:
+    stdin: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: juno-genesis-deployment-repo-secret
+        namespace: argocd
+        labels:
+          argocd.argoproj.io/secret-type: repository
+      stringData:
+        type: git
+        url: "{{ juno_genesis_deployment_git_url }}"
+        password: "{{ juno_genesis_deployment_git_password }}"
+        username: "{{ juno_genesis_deployment_git_username }}"
+  changed_when: "'created' in juno_genesis_deployment_git_password.stdout"
+
+- name: Template in the juno-bootstrap chart
+  become: true
+  ansible.builtin.template:
+    src: juno_bootstrap_chart.yaml.j2
+    dest: /root/juno_bootstrap_chart.yaml
+    mode: "0600"
+    owner: root
+    group: root
+
+- name: Deploy the Juno Bootstrap chart
+  become: true
+  register: juno_bootstrap_chart_deploy_result
+  failed_when: juno_bootstrap_chart_deploy_result.rc != 0 and "'already exists' not in juno_bootstrap_chart_deploy_result.stderr"
+  changed_when: "('configured' in juno_bootstrap_chart_deploy_result.stdout or 'created' in juno_bootstrap_chart_deploy_result.stdout) and juno_bootstrap_chart_deploy_result.rc == 0"
+  ansible.builtin.command:
+    cmd: /usr/local/bin/k3s kubectl apply -f /root/juno_bootstrap_chart.yaml --namespace argocd

--- a/tasks/k3s_install.yml
+++ b/tasks/k3s_install.yml
@@ -28,6 +28,20 @@
     group: root
   become: true
 
+- name: Check if the binary exists, get its checksum
+  ansible.builtin.stat:
+    path: /usr/local/bin/k3s
+  register: k3s_binary_stat
+  become: true
+  failed_when: false
+
+- name: When copying from a local file, checksum it
+  delegate_to: localhost
+  ansible.builtin.stat:
+    path: "{{ k3s_binary_url | regex_replace('^file://', '') }}"
+  register: k3s_binary_local_stat
+  when: "'file://' in k3s_binary_url"
+
 - name: Download the k3s binary (https/s fetch)
   when: "'http://' in k3s_binary_url or 'https://' in k3s_binary_url"
   ansible.builtin.get_url:
@@ -38,32 +52,12 @@
     group: root
   become: true
 
-- name: Download the k3s images (https/s fetch)
-  when:
-    - "'http://' in k3s_images_url or 'https://' in k3s_images_url"
-    - k3s_airgap_install
-  ansible.builtin.get_url:
-    url: "{{ k3s_images_url }}"
-    dest: "/var/lib/rancher/k3s/agent/images/{{ k3s_images_url | basename }}"
-    mode: "0644"
-    owner: root
-    group: root
-  become: true
-
-- name: Copy over the install script (file:// k3s_install_script_url)
-  when:
-    - "'file://' in k3s_install_script_url"
-    - k3s_airgap_install
-  ansible.builtin.copy:
-    src: "{{ k3s_install_script_url | regex_replace('^file://', '') }}"
-    dest: /opt/k3s/install.sh
-    mode: "0755"
-    owner: root
-    group: root
-  become: true
-
+# ToDo: validate the checksum handling here. Something's odd, the copy task takes forever despite ansible checking it on the upstream already: https://github.com/ansible/ansible/blob/240d1a6afb43982f16acebef16778d17aab58160/lib/ansible/plugins/action/copy.py#L283
 - name: Copy over the k3s binary (file:// k3s_binary_url)
-  when: "'file://' in k3s_binary_url"
+  when:
+    - "'file://' in k3s_binary_url"
+    - k3s_binary_stat.stat.exists == false or
+      (k3s_binary_stat.stat.exists and k3s_binary_local_stat.stat.checksum != k3s_binary_stat.stat.checksum)
   ansible.builtin.copy:
     src: "{{ k3s_binary_url | regex_replace('^file://', '') }}"
     dest: /usr/local/bin/k3s
@@ -72,12 +66,36 @@
     group: root
   become: true
 
+- name: Download the k3s images (https/s fetch)
+  when:
+    - "'http://' in k3s_images_url or 'https://' in k3s_images_url"
+    - k3s_copy_images
+  ansible.builtin.get_url:
+    url: "{{ k3s_images_url }}"
+    dest: "/var/lib/rancher/k3s/agent/images/{{ k3s_images_url | basename }}"
+    mode: "0644"
+    owner: root
+    group: root
+  become: true
+
 - name: Copy over the k3s images (file:// k3s_images_url)
-  when: "'file://' in k3s_images_url"
+  when:
+    - "'file://' in k3s_images_url"
+    - k3s_copy_images
   ansible.builtin.copy:
     src: "{{ k3s_images_url | regex_replace('^file://', '') }}"
     dest: "/var/lib/rancher/k3s/agent/images/{{ k3s_images_url | basename }}"
     mode: "0644"
+    owner: root
+    group: root
+  become: true
+
+- name: Copy over the install script (file:// k3s_install_script_url)
+  when: "'file://' in k3s_install_script_url"
+  ansible.builtin.copy:
+    src: "{{ k3s_install_script_url | regex_replace('^file://', '') }}"
+    dest: /opt/k3s/install.sh
+    mode: "0755"
     owner: root
     group: root
   become: true
@@ -92,8 +110,8 @@
   become: true
 
 - name: Template in registries.yaml
-  when: "k3s_registries_yaml | default(False) | bool"
-  ansible.builtin.template:
+  when: "k3s_registries_yaml != false"
+  ansible.builtin.copy:
     content: "{{ k3s_registries_yaml }}"
     dest: /etc/rancher/k3s/registries.yaml
     owner: root
@@ -138,6 +156,11 @@
   ansible.builtin.set_fact:
     flags: "{{ flags + ['--token', k3s_join_token] }}"
   when: k3s_join_token is defined
+
+- name: Add the node-label flags
+  ansible.builtin.set_fact:
+    flags: "{{ flags + (k3s_node_labels | map('regex_replace', '^(.*)$', '--node-label \\1') | list) }}"
+  when: k3s_perform_node_labeling
 
 - name: Install K3s with the constructed flags
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,3 +9,7 @@
 - name: Include k3s_install tasks
   ansible.builtin.include_tasks: k3s_install.yml
   when: not k3s_uninstall | bool
+
+- name: Bootstrap Juno
+  when: juno_install and k3s_control_plane_node
+  ansible.builtin.include_tasks: juno_install.yml

--- a/templates/juno_bootstrap_chart.yaml.j2
+++ b/templates/juno_bootstrap_chart.yaml.j2
@@ -1,0 +1,24 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: juno-bootstrap
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: chart/
+    repoURL: "{{ juno_bootstrap_git_url }}"
+    targetRevision: "{{ juno_bootstrap_chart_repo_revision }}"
+    helm:
+{% if juno_bootstrap_chart_values %}
+      values: |
+        {{ juno_bootstrap_chart_values | to_yaml | indent(6) }}
+{% endif %}
+  syncPolicy:
+    automated: {}

--- a/test_requirements.yml
+++ b/test_requirements.yml
@@ -4,5 +4,6 @@ collections:
     version: 2.26.2
   - name: amazon.aws
     version: 9.5.0
-
+  - name: containers.podman
+    version: 1.16.3
 


### PR DESCRIPTION
This makes the ansible role capable of deploying Juno-Bootstrap in an
airgapped environment.

Running `make converge-airgap-ubuntu24` will get a k3s cluster set up,
install Juno-Bootstrap onto it and get all base deployments in
Genesis-Deployment up&running.

Full ltests will not pass yet. They need minor fixes on idempotency of the
kubectl tasks.

I am already bumping it out so that we can start reviewing it&make it
easier on the timezones.


Next, I will get the docs+examples into K8s-Playbooks and Orion-Documentation, make the autodoc on this repo (juno_k3s) produce better output and we can call this topic done then.